### PR TITLE
fix for yellow soul shots crashing

### DIFF
--- a/scripts/snd_play_ex/snd_play_ex.gml
+++ b/scripts/snd_play_ex/snd_play_ex.gml
@@ -5,5 +5,5 @@
 /// @param	{bool}			loop
 function snd_play_ex(_sound_handle, _priority, _loop)
 {
-	audio_play_sound(_sound_handle, _priority, _loop, 1 * (global.decomp_vars.SoundFXVolume / 100))
+	return audio_play_sound(_sound_handle, _priority, _loop, 1 * (global.decomp_vars.SoundFXVolume / 100))
 }


### PR DESCRIPTION
the yellow soul shots try calling audio_sound_gain on the return value of snd_play_ex (which is undefined, because it never returns anything) this causes it to crash. Other parts of the code use this function in the same way, and probably crash in a similar way.

This was crashing on my version of the decomp, main branch, no changes.
I've tested this fix for myself and it appears to work.